### PR TITLE
FIX for issue #10: Set correct defualt SPI bus speed.

### DIFF
--- a/RPiMCP23S17/MCP23S17.py
+++ b/RPiMCP23S17/MCP23S17.py
@@ -107,6 +107,8 @@ class MCP23S17(object):
         """
         self._setupGPIO()
         self._spi.open(self._bus, self._pin_cs)
+        self._spi.max_speed_hz = 10000000
+
         self.isInitialized = True
         self._writeRegister(MCP23S17.MCP23S17_IOCON, MCP23S17.IOCON_INIT)
 


### PR DESCRIPTION
If this value is not set, the RPi default SPI bus speed is 125Mhz, which
is out of spec for the MCP23S17.