### PR TITLE
FIX issue #11 point 1): Fix off by one when initializing direction and pullup mode

### DIFF
--- a/RPiMCP23S17/MCP23S17.py
+++ b/RPiMCP23S17/MCP23S17.py
@@ -111,7 +111,7 @@ class MCP23S17(object):
         self._writeRegister(MCP23S17.MCP23S17_IOCON, MCP23S17.IOCON_INIT)
 
         # set defaults
-        for index in range(0, 15):
+        for index in range(0, 16):
             self.setDirection(index, MCP23S17.DIR_INPUT)
             self.setPullupMode(index, MCP23S17.PULLUP_ENABLED)
 


### PR DESCRIPTION
[*range(0,16)] gives: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
which sets all bits.